### PR TITLE
invalidate metadata display if configs change

### DIFF
--- a/islandora_solr_metadata.module
+++ b/islandora_solr_metadata.module
@@ -189,3 +189,17 @@ function islandora_solr_metadata_preprocess_islandora_dublin_core_display(&$vari
     ->addCacheableDependency($config)
     ->applyTo($variables);
 }
+
+/**
+ * Implements hook_preprocess_islandora_dublin_core_description().
+ *
+ * While the description display system could use an overhaul this should let
+ * us invalidate the cache for now.
+ */
+function islandora_solr_metadata_preprocess_islandora_dublin_core_description(&$variables) {
+  $config = \Drupal::config('islandora_solr_metadata.configs');
+
+  CacheableMetadata::createFromRenderArray($variables)
+    ->addCacheableDependency($config)
+    ->applyTo($variables);
+}

--- a/islandora_solr_metadata.module
+++ b/islandora_solr_metadata.module
@@ -5,6 +5,8 @@
  * The main module file for the islandora_solr_metadata module.
  */
 
+use Drupal\Core\Cache\CacheableMetadata;
+
 /**
  * Implements hook_theme().
  */
@@ -172,4 +174,18 @@ function islandora_solr_metadata_description_callback(AbstractObject $object) {
   else {
     return FALSE;
   }
+}
+
+/**
+ * Implements hook_preprocess_islandora_dublin_core_display().
+ *
+ * While the metadata display system could use an overhaul this should let us
+ * invalidate the cache for now.
+ */
+function islandora_solr_metadata_preprocess_islandora_dublin_core_display(&$variables) {
+  $config = \Drupal::config('islandora_solr_metadata.configs');
+
+  CacheableMetadata::createFromRenderArray($variables)
+    ->addCacheableDependency($config)
+    ->applyTo($variables);
 }


### PR DESCRIPTION
Better metadata cache.
# What does this Pull Request do?

It adds the Solr metadata configs to the dublin core metadata display cache info.

This is so that when a content model is added to a config object displays will update.
