### PR TITLE
Add expected operator.

### DIFF
--- a/includes/db.inc
+++ b/includes/db.inc
@@ -22,7 +22,7 @@ function islandora_solr_metadata_get_associations_by_cmodels(array $cmodels) {
   }
   $results = db_select('islandora_solr_metadata_cmodels', 'i')
     ->fields('i', ['configuration_name'])
-    ->condition('cmodel', $cmodels)
+    ->condition('cmodel', $cmodels, 'IN')
     ->execute()
     ->fetchAllAssoc('configuration_name', PDO::FETCH_ASSOC);
   return $results;


### PR DESCRIPTION
D7 selected the default operator based on the type of value; however,
D8 explicitly uses `=` by default.