### PR TITLE
Fix postgres issue with adding content models

### DIFF
--- a/includes/configurations.features.inc
+++ b/includes/configurations.features.inc
@@ -95,9 +95,7 @@ function islandora_solr_metadata_configurations_features_rebuild($module_name) {
       }
       // Add fields and cmodels, related to config_id.
       islandora_solr_metadata_update_description($config_id, $config_info['description']['description_field'], $config_info['description']['description_label'], $config_info['description']['description_data']);
-      islandora_solr_metadata_add_content_models($config_id, array_map(function ($e) {
-        return array('cmodel' => $e);
-      }, $config_info['cmodels']));
+      islandora_solr_metadata_add_content_models($config_id, $config_info['cmodels']);
       islandora_solr_metadata_add_fields($config_id, $config_info['fields']);
     }
   }


### PR DESCRIPTION
The features hook was passing in an extra layer of nesting compared
to what `islandora_solr_metadata_add_content_models` is expecting. This
causes postgres to simply write "Array" as the value in the database,
since it complains about an array to string conversion.